### PR TITLE
ENH: first_neighbours now never returns -1 but returns true bounds on…

### DIFF
--- a/c/neighbours.c
+++ b/c/neighbours.c
@@ -648,17 +648,18 @@ first_neighbours(int n, int nn, npy_int *i_n, npy_int *seed)
 {
     int k;
 
-    for (k = 0; k < n; k++) {
-        seed[k] = -1;
-    }
-    seed[n] = nn;
-
     seed[i_n[0]] = 0;
 
     for (k = 1; k < nn; k++) {
         if (i_n[k] != i_n[k-1]) {
-            seed[i_n[k]] = k;
+            int l;
+            for (l = i_n[k-1]+1; l <= i_n[k]; l++) {
+                seed[l] = k;
+            }
         }
+    }
+    for (k = i_n[nn-1]+1; k <= n; k++) {
+        seed[k] = nn;
     }
 }
 

--- a/tests/neighbours.py
+++ b/tests/neighbours.py
@@ -142,9 +142,15 @@ class TestNeighbours(matscipytest.MatSciPyTestCase):
 
     def test_first_neighbours(self):
         i = [1,1,1,1,3,3,3]
-        self.assertArrayAlmostEqual(first_neighbours(5, i), [-1,0,-1,4,-1,7])
+        self.assertArrayAlmostEqual(first_neighbours(5, i), [0,0,4,4,7,7])
         i = [0,1,2,3,4,5]
         self.assertArrayAlmostEqual(first_neighbours(6, i), [0,1,2,3,4,5,6])
+        i = [0,1,2,3,5,6]
+        print(first_neighbours(8, i))
+        self.assertArrayAlmostEqual(first_neighbours(8, i), [0,1,2,3,4,4,5,6,6])
+        i = [0,1,2,3,3,5,6]
+        print(first_neighbours(8, i))
+        self.assertArrayAlmostEqual(first_neighbours(8, i), [0,1,2,3,5,5,6,7,7])
 
     def test_multiple_elements(self):
         a = molecule('HCOOH')


### PR DESCRIPTION
… entries even if those do not exist